### PR TITLE
Fix to long press to edit functionality

### DIFF
--- a/app/src/main/java/me/mudkip/moememos/ext/AnnotatedStringExt.kt
+++ b/app/src/main/java/me/mudkip/moememos/ext/AnnotatedStringExt.kt
@@ -3,18 +3,18 @@ package me.mudkip.moememos.ext
 import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.LinkInteractionListener
 import androidx.compose.ui.text.ParagraphStyle
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.UrlAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextIndent
-import androidx.compose.ui.text.withAnnotation
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.sp
 import org.intellij.markdown.MarkdownElementTypes
@@ -25,12 +25,12 @@ import org.intellij.markdown.flavours.gfm.GFMElementTypes
 import org.intellij.markdown.flavours.gfm.GFMTokenTypes
 import java.util.UUID
 
-@OptIn(ExperimentalTextApi::class)
 fun AnnotatedString.Builder.appendMarkdown(
     markdownText: String,
     node: ASTNode,
     depth: Int = 0,
     linkColor: Color,
+    linkInteractionListener: LinkInteractionListener?,
     onImage: (id: String, link: String) -> Unit,
     onCheckbox: (id: String, startOffset: Int, endOffset: Int) -> Unit,
     maxWidth: Float,
@@ -59,6 +59,7 @@ fun AnnotatedString.Builder.appendMarkdown(
                     node = childNode,
                     depth = depth + 1,
                     linkColor = linkColor,
+                    linkInteractionListener = linkInteractionListener,
                     onImage = onImage,
                     onCheckbox = onCheckbox,
                     maxWidth = maxWidth,
@@ -76,30 +77,42 @@ fun AnnotatedString.Builder.appendMarkdown(
                     ?: return this
             val linkText = node.children.find { it.type == MarkdownElementTypes.LINK_TEXT }?.children
 
-            withAnnotation(UrlAnnotation(linkDestination.getTextInNode(markdownText).toString())) {
+            withLink(
+                LinkAnnotation.Url(
+                    url = linkDestination.getTextInNode(markdownText).toString(),
+                    linkInteractionListener = linkInteractionListener
+                )
+            ) {
                 withStyle(SpanStyle(linkColor)) {
-                    linkText?.filterIndexed { index, _ -> index != 0 && index != linkText.size - 1 }?.forEach { childNode ->
-                        appendMarkdown(
-                            markdownText = markdownText,
-                            node = childNode,
-                            depth = depth + 1,
-                            linkColor = linkColor,
-                            onImage = onImage,
-                            onCheckbox = onCheckbox,
-                            maxWidth = maxWidth,
-                            bulletColor = bulletColor,
-                            headlineLarge = headlineLarge,
-                            headlineMedium = headlineMedium,
-                            headlineSmall = headlineSmall
-                        )
-                    } ?: Unit
+                    linkText?.filterIndexed { index, _ -> index != 0 && index != linkText.size - 1 }
+                        ?.forEach { childNode ->
+                            appendMarkdown(
+                                markdownText = markdownText,
+                                node = childNode,
+                                depth = depth + 1,
+                                linkColor = linkColor,
+                                linkInteractionListener = linkInteractionListener,
+                                onImage = onImage,
+                                onCheckbox = onCheckbox,
+                                maxWidth = maxWidth,
+                                bulletColor = bulletColor,
+                                headlineLarge = headlineLarge,
+                                headlineMedium = headlineMedium,
+                                headlineSmall = headlineSmall
+                            )
+                        } ?: Unit
                 }
             }
         }
 
         MarkdownElementTypes.AUTOLINK, GFMTokenTypes.GFM_AUTOLINK -> {
             val linkDestination = node.getTextInNode(markdownText).toString()
-            withAnnotation(UrlAnnotation(linkDestination)) {
+            withLink(
+                LinkAnnotation.Url(
+                    url = linkDestination,
+                    linkInteractionListener = linkInteractionListener
+                )
+            ) {
                 withStyle(SpanStyle(linkColor)) {
                     append(linkDestination)
                 }
@@ -114,6 +127,7 @@ fun AnnotatedString.Builder.appendMarkdown(
                         node = childNode,
                         depth = depth + 1,
                         linkColor = linkColor,
+                        linkInteractionListener = linkInteractionListener,
                         onImage = onImage,
                         onCheckbox = onCheckbox,
                         maxWidth = maxWidth,
@@ -134,6 +148,7 @@ fun AnnotatedString.Builder.appendMarkdown(
                         node = childNode,
                         depth = depth + 1,
                         linkColor = linkColor,
+                        linkInteractionListener = linkInteractionListener,
                         onImage = onImage,
                         onCheckbox = onCheckbox,
                         maxWidth = maxWidth,
@@ -154,6 +169,7 @@ fun AnnotatedString.Builder.appendMarkdown(
                         node = childNode,
                         depth = depth + 1,
                         linkColor = linkColor,
+                        linkInteractionListener = linkInteractionListener,
                         onImage = onImage,
                         onCheckbox = onCheckbox,
                         maxWidth = maxWidth,
@@ -178,6 +194,7 @@ fun AnnotatedString.Builder.appendMarkdown(
                         node = childNode,
                         depth = depth + 1,
                         linkColor = linkColor,
+                        linkInteractionListener = linkInteractionListener,
                         onImage = onImage,
                         onCheckbox = onCheckbox,
                         maxWidth = maxWidth,
@@ -231,6 +248,7 @@ fun AnnotatedString.Builder.appendMarkdown(
                                 node = it,
                                 depth = depth + 1,
                                 linkColor = linkColor,
+                                linkInteractionListener = linkInteractionListener,
                                 onImage = onImage,
                                 onCheckbox = onCheckbox,
                                 maxWidth = maxWidth,
@@ -265,6 +283,7 @@ fun AnnotatedString.Builder.appendMarkdown(
                     node = childNode,
                     depth = depth + 1,
                     linkColor = linkColor,
+                    linkInteractionListener = linkInteractionListener,
                     onImage = onImage,
                     onCheckbox = onCheckbox,
                     maxWidth = maxWidth,
@@ -284,6 +303,7 @@ fun AnnotatedString.Builder.appendMarkdown(
                         node = childNode,
                         depth = depth + 1,
                         linkColor = linkColor,
+                        linkInteractionListener = linkInteractionListener,
                         onImage = onImage,
                         onCheckbox = onCheckbox,
                         maxWidth = maxWidth,
@@ -309,6 +329,7 @@ fun AnnotatedString.Builder.appendMarkdown(
                             node = childNode,
                             depth = depth + 1,
                             linkColor = linkColor,
+                            linkInteractionListener = linkInteractionListener,
                             onImage = onImage,
                             onCheckbox = onCheckbox,
                             maxWidth = maxWidth,

--- a/app/src/main/java/me/mudkip/moememos/ui/component/Markdown.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/component/Markdown.kt
@@ -1,22 +1,16 @@
 package me.mudkip.moememos.ui.component
 
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
-import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
 import me.mudkip.moememos.ext.appendMarkdown
@@ -24,7 +18,6 @@ import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.parser.MarkdownParser
 
-@OptIn(ExperimentalTextApi::class)
 @Composable
 fun Markdown(
     text: String,
@@ -38,7 +31,6 @@ fun Markdown(
     val headlineLarge = MaterialTheme.typography.headlineLarge
     val headlineMedium = MaterialTheme.typography.headlineMedium
     val headlineSmall = MaterialTheme.typography.headlineSmall
-    val uriHandler = LocalUriHandler.current
 
     BoxWithConstraints {
         val (annotatedString, inlineContent) = remember(text, maxWidth) {
@@ -51,6 +43,7 @@ fun Markdown(
                 node = markdownAst,
                 depth = 0,
                 linkColor = linkColor,
+                linkInteractionListener = null, // Use default interaction listener
                 onImage = { key, url ->
                     inlineContent[key] = InlineTextContent(
                         Placeholder(maxWidth.value.sp, (maxWidth.value * 9f / 16f).sp, PlaceholderVerticalAlign.AboveBaseline),
@@ -78,47 +71,11 @@ fun Markdown(
             Pair(builder.toAnnotatedString(), inlineContent)
         }
 
-        ClickableText(
+        Text(
             text = annotatedString,
             modifier = modifier,
             textAlign = textAlign,
             inlineContent = inlineContent,
-            onClick = {
-                annotatedString.getUrlAnnotations(it, it)
-                    .firstOrNull()?.let { url ->
-                        uriHandler.openUri(url.item.url)
-                    }
-            }
         )
     }
-
-
-}
-
-@Composable
-fun ClickableText(
-    text: AnnotatedString,
-    modifier: Modifier = Modifier,
-    textAlign: TextAlign? = null,
-    inlineContent: Map<String, InlineTextContent> = mapOf(),
-    onClick: (Int) -> Unit
-) {
-    val layoutResult = remember { mutableStateOf<TextLayoutResult?>(null) }
-    val pressIndicator = Modifier.pointerInput(onClick) {
-        detectTapGestures { pos ->
-            layoutResult.value?.let { layoutResult ->
-                onClick(layoutResult.getOffsetForPosition(pos))
-            }
-        }
-    }
-
-    Text(
-        text = text,
-        modifier = modifier.then(pressIndicator),
-        textAlign = textAlign,
-        inlineContent = inlineContent,
-        onTextLayout = {
-            layoutResult.value = it
-        }
-    )
 }


### PR DESCRIPTION
Hi, I saw your PR at https://github.com/mudkipme/MoeMemosAndroid/pull/205 and thought I could try to debug the issue you were encountering with `onLongPress` not triggering.

It turns out there was another `detectTapGestures` modifier inside the `MemoContent` component, used for making links parsed from Markdown, clickable. As a result, this handler was consuming all "tap events" over the text, including long presses ([reference in documentation](https://developer.android.com/reference/kotlin/androidx/compose/foundation/gestures/package-summary#(androidx.compose.ui.input.pointer.PointerInputScope).detectTapGestures(kotlin.Function1,kotlin.Function1,kotlin.coroutines.SuspendFunction2,kotlin.Function1))). Therefore, tap events were being ignored by the handler you set in one of the parents in the layout.

As clicking links only requires managing tap actions, I thought I could change the handler with one that only consumes tap events. However, I couldn't find a high-level handler already shipping with Compose that only managed taps, and also allowed long taps to go through to parent nodes in the layout. Creating a custom gesture handler didn't seem that easy either, because while trying to mimic what  `detectTapGestures` without consuming the events, I figured from looking at its code that detecting long taps requires "checking if taps last longer", thus needing to consume press events. 

I noticed URL annotations were deprecated, and that the app was using a custom `ClickableText` component, mimicking what [`androidx.compose.foundation.text.ClickableText`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/text/package-summary#ClickableText(androidx.compose.ui.text.AnnotatedString,androidx.compose.ui.Modifier,androidx.compose.ui.text.TextStyle,kotlin.Boolean,androidx.compose.ui.text.style.TextOverflow,kotlin.Int,kotlin.Function1,kotlin.Function1)) should do, for handling click actions on links. So in the end, I migrated to using [`LinkAnnotation`](https://developer.android.com/reference/kotlin/androidx/compose/ui/text/LinkAnnotation), where each annotation takes a listener that handles the click action directly. This way, tap actions are only handled when performed over the links.
Also note that I didn't provide a custom listener for each of these, removing the previously used `LocalUriHandler` and leaving `linkInteractionListener` null. This is because, by default, links are handled with `androidx.compose.ui.platform.UriHandler` (as documented [here](https://developer.android.com/reference/kotlin/androidx/compose/ui/text/LinkAnnotation.Url)), which should accomplish the same results as the previously used handler, if I'm not mistaken. However, I added an argument to the `appendMarkdown` function, in case changing it may be needed in the future.